### PR TITLE
Fix: Correct env-config.js loading path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@
         try {
           // Attempt to import env-config.js. Ensure the path is correct.
           // If index.html is at the root, and src is a top-level folder, './src/env-config.js' is correct.
-          const configModule = await import('/src/env-config.js'); 
+          const configModule = await import('./src/env-config.js'); 
           window.envConfig = configModule.default; 
           console.log('env-config.js loaded successfully via dynamic import:', window.envConfig);
 


### PR DESCRIPTION
I changed the dynamic import path for `env-config.js` in `index.html` from `/src/env-config.js` to `./src/env-config.js`.

This ensures that the configuration file is loaded correctly, resolving the 404 error and allowing the application to initialize properly.