### PR TITLE
I tried to fix some parsing errors in `index.html` by reconstructing …

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Project Content Hub</title>
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <!-- <link rel="icon" href="favicon.ico" type="image/x-icon"> -->
     <!-- 
     <script>
       // Theme pre-application for documentElement to prevent FOUC - REMOVED
@@ -26,9 +26,9 @@
       })();
     </script> 
     -->
-    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="assets/styles/main.css">
-    <style>
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet"> -->
+    <!-- <link rel="stylesheet" href="assets/styles/main.css"> -->
+    <!-- <style>
         /* General body styles are in main.css */
         /* These styles are specific to the layout of index.html */
         body {
@@ -137,7 +137,7 @@
             /* background-color, color, border are inherited from general button styles or overridden by main.css vars */
         }
 
-    </style>
+    </style> -->
 </head>
 <body>
     <button id="sidebar-toggle-btn">☰</button>

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,7 +17,7 @@
 [[headers]]
   for = "/*" # Apply to all pages
   [headers.values]
-    Permissions-Policy = "geolocation=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), payment=()"
+    Permissions-Policy = "geolocation=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), payment=(), interest-cohort=()"
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
     # Add other security headers here if needed in the future


### PR DESCRIPTION
…the head section.

- I re-wrote the `<head>` section of `index.html` to ensure clean syntax and no hidden characters, in an attempt to resolve a persistent 'SyntaxError: Unexpected token <'.
- CSS links and inline styles in `index.html` remain commented out for diagnostics.
- `EXPRESS/sitruna/index.html` still has knowledgeItems simplified for diagnostics.
- The Permissions-Policy in `netlify.toml` was updated for interest-cohort.
- The favicon link in `index.html` remains commented out.